### PR TITLE
Fixes some gradle scripts

### DIFF
--- a/app/build-config-values.gradle
+++ b/app/build-config-values.gradle
@@ -1,0 +1,14 @@
+android {
+    buildTypes {
+        debug {
+            buildConfigField "String", "BASE_URL", "\"\""
+        }
+        qa {
+            buildConfigField "String", "BASE_URL", "\"\""
+        }
+
+        release {
+            buildConfigField "String", "BASE_URL", "\"\""
+        }
+    }
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,24 +1,47 @@
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
+
+apply from: "$project.rootDir/gradle/scripts/common-android.gradle"
+apply from: "$project.rootDir/gradle/scripts/kotlin-android.gradle"
+
+androidExtensions {
+    experimental = true
+}
 
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "com.fast.dictionary"
-        minSdkVersion 23
-        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
+        debug {
+            minifyEnabled false
+            debuggable true
+        }
+        qa {
+            minifyEnabled false
+            debuggable true
+        }
         release {
             minifyEnabled false
+            debuggable false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+    packagingOptions {
+        exclude 'META-INF/DEPENDENCIES'
+        exclude 'META-INF/INDEX.LIST'
+        exclude 'META-INF/io.netty.versions.properties'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/license.txt'
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/NOTICE.txt'
+        exclude 'META-INF/notice.txt'
+        exclude 'META-INF/ASL2.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,6 @@ buildscript {
     }
 }
 
-plugins {
-    id "com.diffplug.gradle.spotless" version "3.25.0"
-}
-
 allprojects {
     repositories {
         google()
@@ -27,20 +23,7 @@ allprojects {
     }
 }
 
-subprojects {
-    apply plugin: "com.diffplug.gradle.spotless"
-    spotless {
-        java {
-            target '**/*.java'
-            googleJavaFormat()
-            removeUnusedImports()
-        }
-        kotlin {
-            ktlint()
-        }
-    }
-}
 
-task cleanBuildDir(type: Delete) {
+task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/gradle/scripts/common-android.gradle
+++ b/gradle/scripts/common-android.gradle
@@ -1,0 +1,27 @@
+// 'com.android.application' 또는 'com.android.library' Gradle plugin 을 적용한 이후에 import 해야 올바르게 동작합니다.
+android {
+    compileSdkVersion 29
+    buildToolsVersion "29.0.2"
+
+    defaultConfig {
+        minSdkVersion 23
+        targetSdkVersion 29
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    buildTypes {
+        debug { }
+        qa { }
+        release { }
+    }
+
+    lintOptions {
+        checkReleaseBuilds true
+        abortOnError false
+        lintConfig file("$project.rootDir/gradle/configurations/lint-common.xml")
+    }
+}

--- a/gradle/scripts/kotlin-android.gradle
+++ b/gradle/scripts/kotlin-android.gradle
@@ -1,0 +1,19 @@
+// root project 의 kotlin 버전 설정에 의존성이 있습니다.
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "kotlin-kapt"
+
+kapt {
+    // generateStubs true
+    correctErrorTypes true
+}
+
+android {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+}


### PR DESCRIPTION
# AS-IS
Project contains only one gradle file. It should occur duplication when you add some modules.
# TO-BE
Divide some codes to `kotlin-android.gradle` / `common-android.gradle` / `build-config-values.gradle`
## kotlin-android.gradle
It configs kotlin, kotlin extensions, experiments and so on...
## common-android.gradle
It configs some compile options like build version / min sdk version etc...
## build-config-values.gradle
It configs remote service uri, third-party app ids ...